### PR TITLE
QWDFZX bô分大小寫選字。

### DIFF
--- a/src/rime/gear/selector.cc
+++ b/src/rime/gear/selector.cc
@@ -84,7 +84,7 @@ ProcessResult Selector::ProcessKeyEvent(const KeyEvent& key_event) {
   if (!select_keys.empty() &&
       !key_event.ctrl() &&
       ch >= 0x20 && ch < 0x7f) {
-    size_t pos = select_keys.find((char)ch);
+    size_t pos = select_keys.find((char)tolower(ch));
     if (pos != string::npos) {
       index = static_cast<int>(pos);
     }


### PR DESCRIPTION
BDD bô才調試，因為rime_api_console是編號編做`1234`
```
Feature: Caps tshi̍h著時

  Scenario Outline: 大寫Q選詞嘛ē-tàng選詞
    Given Nā詞庫內底有「<jisu>」chit-ê字詞，拼音是「<phengim>」。
     When 先輸入<phahji>閣大寫Q選詞。
     Then 送出「<jisu>」。

    Examples: 例
     | jisu | phengim | phahji |
     | 火車 | hue2 tshia1 | hue2tshia1 |
```

```
      status: composing 
      [hue2 tshia1]|
      page: 1$ (of size 6)
      1. [火車]


```